### PR TITLE
Add shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,48 @@
+{ pkgs ? import <nixpkgs> {}, lib ? pkgs.lib }:
+
+let
+  python3 = pkgs.python3;
+
+  customtkinter = with python3.pkgs; buildPythonPackage rec {
+    pname = "customtkinter";
+    version = "5.2.0";
+    format = "pyproject";
+
+    src = fetchPypi {
+      inherit pname version;
+      hash = "sha256-6TRIqNIhIeIOwW6VlgqDBuF89+AHl2b1gEsuhV5hSTc=";
+    };
+
+    buildInputs = [ setuptools ];
+    propagatedBuildInputs = [ darkdetect typing-extensions ];
+
+    meta = with lib; {
+      changelog = "https://github.com/TomSchimansky/CustomTkinter/releases/tag/${version}";
+      homepage = "https://github.com/TomSchimansky/CustomTkinter";
+      description = "A modern and customizable python UI-library based on Tkinter";
+      license = licenses.mit;
+      maintainers = with maintainers; [ ataraxiasjel ];
+    };
+  };
+
+  myPythonEnv = python3.withPackages (ps: with ps; [
+    customtkinter
+    pillow
+    requests
+    packaging
+  ]);
+in
+
+pkgs.mkShell {
+  buildInputs = [
+    python3
+    myPythonEnv
+    pkgs.python3Packages.tkinter
+    pkgs.android-tools
+  ];
+
+  shellHook = ''
+    echo "You are now using a NIX environment"
+  '';
+}
+


### PR DESCRIPTION
Added a `shell.nix` file to the repository. This is a declarative development environment that can be used with the Nix package manager. It includes dependency Python packages and the Android SDK platform tools.

To enter the development environment, install the [Nix package manager](https://nixos.org/download/) and run the `nix-shell` command.  Adding this file does not change any default behavior.

<details>

<summary> Chinese Translation (using ChatGPT-4) </summary>
  &nbsp;

向仓库添加了一个`shell.nix`文件。这是一个可以与Nix包管理器一起使用的声明式开发环境。它包括依赖的Python包和Android SDK平台工具。

要进入开发环境，请安装[Nix包管理器](https://nixos.org/download/)并运行`nix-shell`命令。添加此文件不会改变任何默认行为。

</details>