### PR TITLE
correct critical typo in boot_patch.py "flase" changed to "false"

### DIFF
--- a/mp/boot_patch.py
+++ b/mp/boot_patch.py
@@ -64,7 +64,7 @@ class BootPatcher(object):
             return False
 
     def __prepare_env(self):
-        bool2str = lambda x: "true" if x else "flase"
+        bool2str = lambda x: "true" if x else "false"
         self.env = {
             "KEEPVERITY": bool2str(self.keep_verity),
             "KEEPFORCEENCRYPT": bool2str(self.keep_forceencrypt),


### PR DESCRIPTION
There is a critical typo in boot_patch.py. This likely doesn't currently hurt anything, as anything that is not equal to the value "true" is going to be false in most logical settings. However it does show up in  the patched ramdisk.cpio /.backup/.magisk:

```
KEEPVERITY=true
KEEPFORCEENCRYPT=true
RECOVERYMODE=flase
```